### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     name: 🛠️ Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,6 +40,8 @@ jobs:
     name: ✅ Test
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
     steps:
       - name: Download build artifact
         uses: actions/download-artifact@v3
@@ -58,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build, test]
     if: github.ref == 'refs/heads/main' && success()
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kiefertaylorland/pokedex/security/code-scanning/9](https://github.com/kiefertaylorland/pokedex/security/code-scanning/9)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for each job. For example:
- The `build` and `test` jobs only need `contents: read` to access the repository code.
- The `deploy` job may require additional permissions, such as `contents: read` and `deployments: write`, depending on its operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or individually for each job. In this case, we will add permissions for each job to ensure granular control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
