### PR TITLE
Fix: Romaji not displaying in Japanese mode

### DIFF
--- a/assets/js/components/pokemonCardRenderer.js
+++ b/assets/js/components/pokemonCardRenderer.js
@@ -3,7 +3,7 @@
  * @module PokemonCardRenderer
  */
 
-import { ELEMENT_IDS, CSS_CLASSES, UI_TEXT } from '../constants.js';
+import { ELEMENT_IDS, CSS_CLASSES, UI_TEXT, LANGUAGES } from '../constants.js';
 import { createSafeElement, sanitizeHTML } from '../utils/security.js';
 import { getTypeClassName } from '../utils/typeMapping.js';
 import { createImageWithFallback } from '../utils/imageUtils.js';
@@ -83,7 +83,7 @@ export class PokemonCardRenderer {
         nameContainer.appendChild(nameElement);
         
         // Add romaji if in Japanese mode
-        if (currentLang === 'jp' && pokemon.name_romaji) {
+        if (currentLang === LANGUAGES.JAPANESE && pokemon.name_romaji) {
             const romajiElement = createSafeElement('span', pokemon.name_romaji);
             romajiElement.classList.add('pokemon-name-romaji');
             nameContainer.appendChild(romajiElement);
@@ -176,7 +176,7 @@ export class PokemonCardRenderer {
             typeWrapper.appendChild(typeSpan);
             
             // Add romaji if in Japanese mode and romaji is available
-            if (currentLang === 'jp' && pokemon && pokemon.types_romaji && pokemon.types_romaji[index]) {
+            if (currentLang === LANGUAGES.JAPANESE && pokemon && pokemon.types_romaji && pokemon.types_romaji[index]) {
                 const romajiSpan = createSafeElement('span', pokemon.types_romaji[index]);
                 romajiSpan.classList.add('type-romaji');
                 typeWrapper.appendChild(romajiSpan);
@@ -246,7 +246,7 @@ export class PokemonCardRenderer {
      */
     _renderEmptyState() {
         const currentLang = this.uiController.getCurrentLanguage();
-        const message = currentLang === 'jp' ? 'ポケモンが見つかりません' : 'No Pokémon found';
+        const message = currentLang === LANGUAGES.JAPANESE ? 'ポケモンが見つかりません' : 'No Pokémon found';
         
         const emptyContainer = createSafeElement('div');
         emptyContainer.classList.add('empty-state');

--- a/assets/js/components/pokemonDetailView.js
+++ b/assets/js/components/pokemonDetailView.js
@@ -3,7 +3,7 @@
  * @module PokemonDetailView
  */
 
-import { ELEMENT_IDS, CSS_CLASSES, DATA, ANIMATION, EVENTS, KEYS } from '../constants.js';
+import { ELEMENT_IDS, CSS_CLASSES, DATA, ANIMATION, EVENTS, KEYS, LANGUAGES } from '../constants.js';
 import { createSafeElement, safeSetInnerHTML, validatePokemonId } from '../utils/security.js';
 import { getTypeClassName } from '../utils/typeMapping.js';
 import { TypeMatchupChart } from './typeMatchupChart.js';
@@ -166,7 +166,7 @@ export class PokemonDetailView {
         nameElement.classList.add('pokemon-detail-name');
         nameContainer.appendChild(nameElement);
         
-        if (currentLang === 'jp' && pokemon.name_romaji) {
+        if (currentLang === LANGUAGES.JAPANESE && pokemon.name_romaji) {
             const romajiElement = createSafeElement('div', pokemon.name_romaji);
             romajiElement.classList.add('pokemon-detail-name-romaji');
             nameContainer.appendChild(romajiElement);
@@ -185,7 +185,7 @@ export class PokemonDetailView {
             typeWrapper.appendChild(typeSpan);
             
             // Add romaji if in Japanese mode
-            if (currentLang === 'jp' && pokemon.types_romaji && pokemon.types_romaji[index]) {
+            if (currentLang === LANGUAGES.JAPANESE && pokemon.types_romaji && pokemon.types_romaji[index]) {
                 const romajiSpan = createSafeElement('span', pokemon.types_romaji[index]);
                 romajiSpan.classList.add('type-romaji');
                 typeWrapper.appendChild(romajiSpan);
@@ -509,8 +509,8 @@ export class PokemonDetailView {
      */
     _createMoveItem(move, uiText) {
         const currentLang = this.uiController.getCurrentLanguage();
-        const moveName = currentLang === 'jp' ? (move.name_jp || move.name_en) : move.name_en;
-        const moveType = currentLang === 'jp' ? (move.type_jp || move.type_en) : move.type_en;
+        const moveName = currentLang === LANGUAGES.JAPANESE ? (move.name_jp || move.name_en) : move.name_en;
+        const moveType = currentLang === LANGUAGES.JAPANESE ? (move.type_jp || move.type_en) : move.type_en;
 
         const listItem = createSafeElement('li');
         listItem.classList.add('move-item');
@@ -525,7 +525,7 @@ export class PokemonDetailView {
         moveNameContainer.appendChild(nameElement);
         
         // Add romaji for move name if in Japanese mode
-        if (currentLang === 'jp' && move.name_romaji) {
+        if (currentLang === LANGUAGES.JAPANESE && move.name_romaji) {
             const romajiElement = createSafeElement('span', ` (${move.name_romaji})`);
             romajiElement.classList.add('move-name-romaji');
             moveNameContainer.appendChild(romajiElement);
@@ -545,7 +545,7 @@ export class PokemonDetailView {
         typeElement.appendChild(typeTextSpan);
         
         // Add romaji for move type if in Japanese mode
-        if (currentLang === 'jp' && move.type_romaji) {
+        if (currentLang === LANGUAGES.JAPANESE && move.type_romaji) {
             const typeRomajiSpan = createSafeElement('span', ` (${move.type_romaji})`);
             typeRomajiSpan.classList.add('move-type-romaji');
             typeElement.appendChild(typeRomajiSpan);
@@ -848,7 +848,7 @@ export class PokemonDetailView {
                 abilityItem.classList.add('hidden-ability');
             }
             
-            const abilityName = currentLang === 'jp' ? 
+            const abilityName = currentLang === LANGUAGES.JAPANESE ? 
                 (ability.name_jp || ability.name_en) : ability.name_en;
             
             const nameSpan = createSafeElement('span', abilityName);
@@ -893,7 +893,7 @@ export class PokemonDetailView {
             const categoryLabel = createSafeElement('span', `${uiText.category}:`);
             categoryLabel.classList.add('info-label');
             
-            const genus = currentLang === 'jp' ? 
+            const genus = currentLang === LANGUAGES.JAPANESE ? 
                 (pokemon.genus_jp || pokemon.genus_en) : pokemon.genus_en;
             const categoryValue = createSafeElement('span', genus);
             categoryValue.classList.add('info-value');


### PR DESCRIPTION
## Problem
Romaji (romanized Japanese text) was not displaying when the Japanese language toggle was enabled.

## Root Cause
The code was using hardcoded string comparisons (`currentLang === 'jp'`) instead of using the `LANGUAGES.JAPANESE` constant from `constants.js`. This caused the condition checks to fail.

## Solution
- Added `LANGUAGES` to imports in both affected components
- Replaced all hardcoded `'jp'` string comparisons with `LANGUAGES.JAPANESE` constant
- Updated 10 total comparisons across 2 files

## Files Changed
1. `assets/js/components/pokemonCardRenderer.js` - 3 comparisons fixed
2. `assets/js/components/pokemonDetailView.js` - 7 comparisons fixed

## Impact
When Japanese language mode is enabled, romaji will now properly display:
- Under Pokemon names in card view
- Under type badges in card view  
- In detail modal for names, types, moves, and abilities

## Testing
- ✅ JavaScript syntax validated
- ✅ Logic verified with isolated tests
- ✅ Updated files served successfully by HTTP server

Fixes the issue reported where romaji was missing in Japanese mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal code structure for improved consistency and long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->