### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/pokeapi_fetch.py
+++ b/pokeapi_fetch.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 from typing import Dict, List, Any, Optional, Tuple
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 
 # Configure logging
 logging.basicConfig(
@@ -371,11 +372,13 @@ def fetch_and_build_pokedex(pokemon_count=POKEMON_COUNT, base_url=BASE_URL, slee
         
         # Get additional sprites and convert to jsDelivr CDN
         def convert_sprite_url(url):
-            if url and "raw.githubusercontent.com" in url:
-                return url.replace(
-                    "https://raw.githubusercontent.com/",
-                    "https://cdn.jsdelivr.net/gh/"
-                ).replace("/master/", "@master/")
+            if url:
+                parsed = urlparse(url)
+                if parsed.hostname == "raw.githubusercontent.com":
+                    return url.replace(
+                        "https://raw.githubusercontent.com/",
+                        "https://cdn.jsdelivr.net/gh/"
+                    ).replace("/master/", "@master/")
             return url
         
         sprites = {


### PR DESCRIPTION
Potential fix for [https://github.com/kiefertaylorland/pokedex/security/code-scanning/12](https://github.com/kiefertaylorland/pokedex/security/code-scanning/12)

The best way to fix this issue is to stop using substring checks on URLs altogether and instead parse the URL with a standard library function and then inspect its `hostname` attribute. Specifically, in the `convert_sprite_url` function, before performing any replacements, we should parse the URL using `urllib.parse.urlparse` and check that the hostname is exactly `"raw.githubusercontent.com"`. Only if this is true should we proceed with the conversion to the jsDelivr format. This change should be made in the definition of the `convert_sprite_url` function (lines 373-380). Additionally, you should import `urlparse` from `urllib.parse` at the top of the file if it is not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sprite URL handling to more reliably detect and process URLs from external sources, ensuring consistent content delivery network integration while maintaining compatibility with non-URL inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->