### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete URL substring sanitization

### DIFF
--- a/pokeapi_fetch.py
+++ b/pokeapi_fetch.py
@@ -5,6 +5,7 @@ import argparse
 import logging
 from typing import Dict, List, Any, Optional, Tuple
 from datetime import datetime, timedelta
+from urllib.parse import urlparse
 
 # Configure logging
 logging.basicConfig(
@@ -464,11 +465,13 @@ def fetch_and_build_pokedex(pokemon_count=POKEMON_COUNT, base_url=BASE_URL, slee
         
         # Convert sprite URLs to jsDelivr CDN for better reliability
         sprite_url = pokemon_main_data["sprites"]["front_default"]
-        if sprite_url and "raw.githubusercontent.com" in sprite_url:
-            sprite_url = sprite_url.replace(
-                "https://raw.githubusercontent.com/",
-                "https://cdn.jsdelivr.net/gh/"
-            ).replace("/master/", "@master/")
+        if sprite_url:
+            parsed_url = urlparse(sprite_url)
+            if parsed_url.hostname == "raw.githubusercontent.com":
+                sprite_url = sprite_url.replace(
+                    "https://raw.githubusercontent.com/",
+                    "https://cdn.jsdelivr.net/gh/"
+                ).replace("/master/", "@master/")
         
         pokemon_obj = {
             "id": pokemon_main_data["id"],


### PR DESCRIPTION
Potential fix for [https://github.com/kiefertaylorland/pokedex/security/code-scanning/13](https://github.com/kiefertaylorland/pokedex/security/code-scanning/13)

To fix the issue, parse the URL using Python’s `urllib.parse` module, extract the hostname, and verify that it matches `raw.githubusercontent.com` exactly before performing the substitution. This ensures the rewrite only happens for URLs genuinely originating from the allowed host, preventing accidental or malicious replacements of URLs from other origins.

Specifically, in `pokeapi_fetch.py`, on lines 467–472:  
- Use `urlparse` to extract the hostname from `sprite_url`.
- Replace the current `"raw.githubusercontent.com" in sprite_url` check with a comparison such as `parsed_url.hostname == "raw.githubusercontent.com"`.
- Only perform the replacement if the hostname matches.
- Add the import `from urllib.parse import urlparse` if it is not already present.

This change ensures the check is no longer a substring search but an explicit and reliable domain comparison.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of URL handling for sprite data retrieval with enhanced validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->